### PR TITLE
Add support for clearing URL and image cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a MinUI tool package (`.pak`) that scrapes artwork from the Libretro Thumbnails Server for retro gaming devices. It's written primarily in shell script and targets ARM-based gaming handhelds running MinUI/NextUI.
+
+## Development Commands
+
+### Build Commands
+```bash
+# Clean build artifacts
+make clean
+
+# Build all dependencies (downloads pre-built binaries)
+make build
+
+# Create release package
+make release
+
+# Version bump (requires RELEASE_VERSION environment variable)
+make bump-version RELEASE_VERSION=x.y.z
+
+# Push to device via ADB
+make push PUSH_SDCARD_PATH=/mnt/SDCARD PUSH_PLATFORM=tg5040
+```
+
+### Testing
+- No unit tests exist - testing is done via CI/CD pipeline
+- CI runs on ARM-based Ubuntu runners and validates build artifacts
+- Manual testing requires a physical MinUI device or ADB access
+
+## Architecture
+
+### Core Components
+
+1. **launch.sh** - Main entry point that:
+   - Sets up environment variables and paths
+   - Manages UI through `minui-list` and `minui-presenter`
+   - Handles artwork fetching and caching
+   - Integrates with remote image matching service
+
+2. **Remote Service Integration**
+   - Uses `https://matching-images-is.bittersweet.rip` for fuzzy ROM name matching
+   - Service endpoint: `POST /matches/{emu_name}/{art_type}`
+   - Input: List of ROM filenames
+   - Output: Tab-delimited file with ROM name to artwork URL mappings
+
+3. **Caching Strategy**
+   - Match cache: `$SDCARD_PATH/Artwork/.cache/matches/`
+   - Downloaded images: `$SDCARD_PATH/Artwork/{ROM_FOLDER}/{ART_TYPE}/`
+   - User configuration: `$USERDATA_PATH/Artwork Scraper/`
+
+4. **Platform Detection**
+   - Supports `arm` and `arm64` architectures
+   - Platform-specific binaries in `bin/{architecture}/` and `bin/{platform}/`
+   - Currently supports `tg5040` platform (Trimui devices)
+
+### Key Environment Variables
+- `$SDCARD_PATH` - Root path of SD card
+- `$USERDATA_PATH` - User data directory (`.userdata/$PLATFORM/`)
+- `$LOGS_PATH` - Debug log location
+- `$PLATFORM` - Current device platform (e.g., `tg5040`)
+
+### Image Processing
+- MinUI requires images to be resized to 300px width (uses `graphicsmagick`)
+- NextUI handles scaling in software
+- Supported art types: `snap` (default), `title`, `boxart`
+
+## Dependencies
+
+External binaries downloaded during build:
+- `jq` (v1.7.1) - JSON processing
+- `minui-list` (v0.11.4) - Terminal UI list component
+- `minui-presenter` (v0.7.0) - Message display component
+- `graphicsmagick` (`gm`) - Image resizing (expected on device)
+
+## Release Process
+
+1. Run `make release` to create distribution package
+2. Creates `dist/Artwork Scraper.pak.zip` containing all necessary files
+3. Version is automatically bumped if `RELEASE_VERSION` is provided
+4. GitHub Actions handles attestation and artifact upload

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use the correct platform for your device.
 > [!IMPORTANT]
 > If the zip file was not extracted correctly, the pak may show up under `Tools > Artwork`. Rename the folder to `Artwork Scraper.pak` to fix this.
 
-Browse to `Tools > Artwork Scraper` and press `A` to enter the Pak. A list of emulator folders with roms inside will be populated. Selecting a folder will hit a [remote server](https://matching-images-is.bittersweet.rip) running the [`libretro-image-matching-server`](https://github.com/josegonzalez/libretro-image-matching-server) codebase for matching rom names to `Named_Snap` images, which will be cached to disk for later usage. Once the cache is populated, all the matched will be downloaded and moved into the correct folder for either MinUI or NextUI.
+Browse to `Tools > Artwork Scraper` and press `A` to enter the Pak. A list of emulator folders with roms inside will be populated, with a "Clear Cache" option at the top. Selecting a folder will hit a [remote server](https://matching-images-is.bittersweet.rip) running the [`libretro-image-matching-server`](https://github.com/josegonzalez/libretro-image-matching-server) codebase for matching rom names to `Named_Snap` images, which will be cached to disk for later usage. Once the cache is populated, all the matched will be downloaded and moved into the correct folder for either MinUI or NextUI.
 
 - Images are downloaded from the [Libretro Thumbnails Server](https://thumbnails.libretro.com/) and cached locally to an `Artwork` directory.
 - By default, `snap` (image screenshots) are the art type downloaded, but `title` and `boxart` can also be used.
@@ -35,6 +35,14 @@ Browse to `Tools > Artwork Scraper` and press `A` to enter the Pak. A list of em
 
 > [!WARNING]
 > Please note that it is currently not possible to exit out of the scraping process once it has started. You may need to power down your device to force-exit scraping.
+
+### Clear Cache
+
+The "Clear Cache" option appears at the top of the emulator list and allows you to manage the cached data:
+
+- **Clear URL cache only**: Removes the cached mappings between ROM names and artwork URLs. This forces the scraper to re-query the remote server for matches.
+- **Clear image cache only**: Removes all downloaded artwork images while preserving the URL mappings. This is useful if you want to re-download images without re-matching.
+- **Clear all cache**: Removes both URL mappings and downloaded images, giving you a fresh start.
 
 ### Configuration
 

--- a/launch.sh
+++ b/launch.sh
@@ -192,7 +192,7 @@ clear_all_cache() {
     show_message "Clearing all cache..." forever
     rm -rf "$SDCARD_PATH/Artwork/.cache"
     # Remove all cached images but keep the directory structure
-    find "$SDCARD_PATH/Artwork" -name "*.png" -type f -delete 2>/dev/null || true
+    find "$SDCARD_PATH/Artwork" -name "*.*" -type f -delete 2>/dev/null || true
     sync
     show_message "All cache cleared" 2
 }

--- a/launch.sh
+++ b/launch.sh
@@ -41,6 +41,11 @@ populate_emus_list() {
         fi
     done </tmp/emus
     sed -i '/^[.]/d; /^APPS/d; /^PORTS/d' /tmp/emus.list
+    
+    # Add Clear Cache option at the top
+    echo "Clear Cache" > /tmp/emus.list.tmp
+    cat /tmp/emus.list >> /tmp/emus.list.tmp
+    mv /tmp/emus.list.tmp /tmp/emus.list
 }
 
 main_screen() {
@@ -168,6 +173,68 @@ show_message() {
     fi
 }
 
+clear_url_cache() {
+    show_message "Clearing URL cache..." forever
+    rm -rf "$SDCARD_PATH/Artwork/.cache/matches"
+    sync
+    show_message "URL cache cleared" 2
+}
+
+clear_image_cache() {
+    show_message "Clearing image cache..." forever
+    # Remove all cached images but keep the directory structure
+    find "$SDCARD_PATH/Artwork" -name "*.png" -type f -delete 2>/dev/null || true
+    sync
+    show_message "Image cache cleared" 2
+}
+
+clear_all_cache() {
+    show_message "Clearing all cache..." forever
+    rm -rf "$SDCARD_PATH/Artwork/.cache"
+    # Remove all cached images but keep the directory structure
+    find "$SDCARD_PATH/Artwork" -name "*.png" -type f -delete 2>/dev/null || true
+    sync
+    show_message "All cache cleared" 2
+}
+
+cache_menu() {
+    # Create cache menu options
+    cat > /tmp/cache_menu.list <<EOF
+Clear URL cache only
+Clear image cache only
+Clear all cache
+EOF
+
+    killall minui-presenter >/dev/null 2>&1 || true
+    minui-list --disable-auto-sleep --item-key "cache_options" --file "/tmp/cache_menu.list" --format text --cancel-text "BACK" --title "Clear Cache" --write-location /tmp/cache-output --write-value state
+    
+    exit_code=$?
+    if [ "$exit_code" -ne 0 ]; then
+        rm -f /tmp/cache_menu.list /tmp/cache-output
+        return 1
+    fi
+    
+    output="$(cat /tmp/cache-output)"
+    selected_index="$(echo "$output" | jq -r '.selected')"
+    selection="$(echo "$output" | jq -r ".cache_options[$selected_index].name")"
+    
+    rm -f /tmp/cache_menu.list /tmp/cache-output
+    
+    case "$selection" in
+        "Clear URL cache only")
+            clear_url_cache
+            ;;
+        "Clear image cache only")
+            clear_image_cache
+            ;;
+        "Clear all cache")
+            clear_all_cache
+            ;;
+    esac
+    
+    return 0
+}
+
 cleanup() {
     rm -f /tmp/stay_awake
     rm -f /tmp/emus
@@ -218,6 +285,14 @@ main() {
 
         if [ -z "$selection" ]; then
             show_message "No selection made" forever
+            continue
+        fi
+        
+        # Handle Clear Cache selection
+        if [ "$selection" = "Clear Cache" ]; then
+            cache_menu
+            # Refresh the emus list to ensure it's up to date
+            rm -f /tmp/emus.list
             continue
         fi
 


### PR DESCRIPTION
## Summary
- Add "Clear Cache" option to the main menu
- Implement three cache clearing options:
  - Clear URL cache only (removes match mappings from `.cache/matches/`)
  - Clear image cache only (removes downloaded images while preserving mappings)
  - Clear all cache (removes both URL mappings and downloaded images)
- Update README with Clear Cache documentation
- Add CLAUDE.md for future development guidance

## Test plan
- [ ] Verify "Clear Cache" appears as first option in main menu
- [ ] Test URL cache clearing removes files from `$SDCARD_PATH/Artwork/.cache/matches/`
- [ ] Test image cache clearing removes .png files but preserves directory structure
- [ ] Test "Clear all cache" removes both URL and image caches
- [ ] Verify cache menu navigation works correctly (back button, selection handling)
- [ ] Test on actual MinUI device to ensure UI integration works properly

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)