### PR TITLE
Add support for deleting one or all images for a given emulator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+MinUI Artwork Scraper is a shell script-based application packaged as a MinUI `.pak` for handheld gaming devices. It automatically downloads game artwork from the Libretro Thumbnails Server based on ROM names.
+
+## Key Commands
+
+### Development
+```bash
+# Download required binaries (jq, minui-list, minui-presenter)
+make build
+
+# Create a distributable zip package
+make release
+
+# Update version in pak.json
+make bump-version RELEASE_VERSION=x.x.x
+
+# Deploy to device via ADB for testing
+make push
+
+# Clean built binaries
+make clean
+```
+
+### Testing
+To test locally, you need:
+1. A tg5040 platform device (Trimui Brick/Smart Pro) connected via ADB
+2. Run `make push` to deploy
+3. Launch from the Tools menu in MinUI
+
+## Architecture
+
+### Core Components
+- **launch.sh**: Main application entry point that handles:
+  - Environment setup (PATH, LD_LIBRARY_PATH for platform binaries)
+  - UI presentation using `minui-list` for emulator selection
+  - API calls to matching server (`https://matching-images-is.bittersweet.rip`)
+  - Image downloading from Libretro Thumbnails Server
+  - Image processing and placement in `.res` (MinUI) or `.media` (NextUI) folders
+
+### External Dependencies
+- **Matching Server API**: `https://matching-images-is.bittersweet.rip/match` - Returns artwork URLs for ROM names
+- **Image Source**: Libretro Thumbnails Server - Hosts the actual artwork files
+- **Platform Tools**: `minui-list`, `minui-presenter`, `gm` (GraphicsMagick) - UI and image processing
+
+### Directory Structure
+- `bin/`: Platform-specific binaries (jq for ARM/ARM64)
+- `bin/tg5040/`: Platform tools (minui-list, minui-presenter, gm)
+- `lib/tg5040/`: Shared libraries (libjpeg, libpng, libz)
+
+### Image Processing Flow
+1. User selects emulator via `minui-list`
+2. Script reads ROMs from emulator directory
+3. Calls matching API with ROM names
+4. Downloads images to local cache (`.cache/minui_artwork_scraper/`)
+5. Copies/scales images to appropriate folders:
+   - MinUI: `.res/` folders with 300px width scaling
+   - NextUI: `.media/` folders without scaling
+
+### Configuration
+- Art type selection stored in `.userdata/$PLATFORM/.minui_artwork_scraper/.arttype`
+- Options: snap (default), title, boxart
+- Debug logs written to `.userdata/$PLATFORM/logs/minui_artwork_scraper.log`
+
+## Development Notes
+
+- The application runs in MinUI's environment with specific PATH requirements
+- All user interaction happens through MinUI's presenter tools
+- Error handling includes user-friendly messages via `minui-presenter`
+- The script handles both MinUI and NextUI folder structures
+- Platform detection is hardcoded to `tg5040` - extending to other platforms requires binary additions

--- a/launch.sh
+++ b/launch.sh
@@ -57,6 +57,50 @@ main_screen() {
     minui-list --disable-auto-sleep --item-key "folders" --file "/tmp/emus.list" --format text --cancel-text "EXIT" --title "Artwork Scraper" --write-location /tmp/minui-output --write-value state
 }
 
+action_menu() {
+    ROM_FOLDER="$1"
+    
+    rm -f /tmp/action.list /tmp/action-output
+    echo "Download Artwork" > /tmp/action.list
+    echo "Delete Artwork" >> /tmp/action.list
+    
+    killall minui-presenter >/dev/null 2>&1 || true
+    minui-list --disable-auto-sleep --item-key "actions" --file "/tmp/action.list" --format text --cancel-text "BACK" --title "$ROM_FOLDER" --write-location /tmp/action-output --write-value state
+    
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+    
+    output="$(cat /tmp/action-output)"
+    selected_index="$(echo "$output" | jq -r '.selected')"
+    selection="$(echo "$output" | jq -r ".actions[$selected_index].name")"
+    
+    echo "$selection"
+    return 0
+}
+
+delete_menu() {
+    ROM_FOLDER="$1"
+    
+    rm -f /tmp/delete.list /tmp/delete-output
+    echo "Delete All Images" > /tmp/delete.list
+    echo "Delete Individual Images" >> /tmp/delete.list
+    
+    killall minui-presenter >/dev/null 2>&1 || true
+    minui-list --disable-auto-sleep --item-key "options" --file "/tmp/delete.list" --format text --cancel-text "BACK" --title "Delete $ROM_FOLDER Artwork" --write-location /tmp/delete-output --write-value state
+    
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+    
+    output="$(cat /tmp/delete-output)"
+    selected_index="$(echo "$output" | jq -r '.selected')"
+    selection="$(echo "$output" | jq -r ".options[$selected_index].name")"
+    
+    echo "$selection"
+    return 0
+}
+
 fetch_artwork() {
     ROM_FOLDER="$1" ART_TYPE="${2:-snap}" REFRESH_CACHE="${3:-false}"
     rom_file="$SDCARD_PATH/Artwork/.cache/matches/$ROM_FOLDER.in.txt"
@@ -168,10 +212,141 @@ show_message() {
     fi
 }
 
+confirm_action() {
+    message="$1"
+    
+    rm -f /tmp/confirm.list /tmp/confirm-output
+    echo "Yes" > /tmp/confirm.list
+    echo "No" >> /tmp/confirm.list
+    
+    killall minui-presenter >/dev/null 2>&1 || true
+    minui-list --disable-auto-sleep --item-key "choices" --file "/tmp/confirm.list" --format text --cancel-text "CANCEL" --title "$message" --write-location /tmp/confirm-output --write-value state
+    
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+    
+    output="$(cat /tmp/confirm-output)"
+    selected_index="$(echo "$output" | jq -r '.selected')"
+    selection="$(echo "$output" | jq -r ".choices[$selected_index].name")"
+    
+    if [ "$selection" = "Yes" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+delete_all_images() {
+    ROM_FOLDER="$1"
+    
+    confirm_action "Delete all artwork for $ROM_FOLDER?"
+    if [ $? -ne 0 ]; then
+        show_message "Deletion cancelled" 2
+        return 1
+    fi
+    
+    show_message "Deleting all images..." forever
+    
+    # Delete from cache
+    rm -rf "$SDCARD_PATH/Artwork/$ROM_FOLDER"
+    
+    # Delete from rom folders (.res and .media)
+    base_directory="$SDCARD_PATH/Roms/$ROM_FOLDER"
+    rm -rf "$base_directory/.res"
+    rm -rf "$base_directory/.media"
+    
+    # Delete cache files
+    rm -f "$SDCARD_PATH/Artwork/.cache/matches/$ROM_FOLDER.in.txt"
+    rm -f "$SDCARD_PATH/Artwork/.cache/matches/$ROM_FOLDER."*.out.txt
+    
+    sync
+    show_message "All images deleted" 3
+    return 0
+}
+
+select_images_to_delete() {
+    ROM_FOLDER="$1"
+    base_directory="$SDCARD_PATH/Roms/$ROM_FOLDER"
+    
+    # Determine which folder to check
+    image_folder=".res"
+    if [ -d "$base_directory/.media" ]; then
+        image_folder=".media"
+    fi
+    
+    if [ ! -d "$base_directory/$image_folder" ]; then
+        show_message "No images found" 2
+        return 1
+    fi
+    
+    # Create list of images
+    rm -f /tmp/images.list /tmp/images-output
+    ls -1 "$base_directory/$image_folder"/*.png 2>/dev/null | while read -r img; do
+        basename "$img" >> /tmp/images.list
+    done
+    
+    if [ ! -s /tmp/images.list ]; then
+        show_message "No images found" 2
+        return 1
+    fi
+    
+    killall minui-presenter >/dev/null 2>&1 || true
+    minui-list --disable-auto-sleep --item-key "images" --file "/tmp/images.list" --format text --cancel-text "BACK" --title "Select image to delete" --write-location /tmp/images-output --write-value state
+    
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+    
+    output="$(cat /tmp/images-output)"
+    selected_index="$(echo "$output" | jq -r '.selected')"
+    selection="$(echo "$output" | jq -r ".images[$selected_index].name")"
+    
+    if [ -n "$selection" ]; then
+        delete_single_image "$ROM_FOLDER" "$selection"
+    fi
+}
+
+delete_single_image() {
+    ROM_FOLDER="$1"
+    IMAGE_NAME="$2"
+    
+    confirm_action "Delete $IMAGE_NAME?"
+    if [ $? -ne 0 ]; then
+        show_message "Deletion cancelled" 2
+        return 1
+    fi
+    
+    show_message "Deleting image..." forever
+    
+    # Delete from cache (all art types)
+    rm -f "$SDCARD_PATH/Artwork/$ROM_FOLDER/snap/$IMAGE_NAME"
+    rm -f "$SDCARD_PATH/Artwork/$ROM_FOLDER/title/$IMAGE_NAME"
+    rm -f "$SDCARD_PATH/Artwork/$ROM_FOLDER/boxart/$IMAGE_NAME"
+    
+    # Delete from rom folders
+    base_directory="$SDCARD_PATH/Roms/$ROM_FOLDER"
+    rm -f "$base_directory/.res/$IMAGE_NAME"
+    rm -f "$base_directory/.media/$IMAGE_NAME"
+    
+    sync
+    show_message "Image deleted" 2
+    return 0
+}
+
 cleanup() {
     rm -f /tmp/stay_awake
     rm -f /tmp/emus
+    rm -f /tmp/emus.list
     rm -f /tmp/minui-output
+    rm -f /tmp/action.list
+    rm -f /tmp/action-output
+    rm -f /tmp/delete.list
+    rm -f /tmp/delete-output
+    rm -f /tmp/confirm.list
+    rm -f /tmp/confirm-output
+    rm -f /tmp/images.list
+    rm -f /tmp/images-output
     killall minui-presenter >/dev/null 2>&1 || true
 }
 
@@ -221,9 +396,26 @@ main() {
             continue
         fi
 
-        art_type="$(get_art_type)"
-        show_message "Fetching $art_type images for $selection" forever
-        fetch_artwork "$selection" "$art_type"
+        # Show action menu
+        action=$(action_menu "$selection")
+        if [ $? -ne 0 ]; then
+            continue
+        fi
+        
+        if [ "$action" = "Download Artwork" ]; then
+            art_type="$(get_art_type)"
+            show_message "Fetching $art_type images for $selection" forever
+            fetch_artwork "$selection" "$art_type"
+        elif [ "$action" = "Delete Artwork" ]; then
+            delete_option=$(delete_menu "$selection")
+            if [ $? -eq 0 ]; then
+                if [ "$delete_option" = "Delete All Images" ]; then
+                    delete_all_images "$selection"
+                elif [ "$delete_option" = "Delete Individual Images" ]; then
+                    select_images_to_delete "$selection"
+                fi
+            fi
+        fi
     done
 }
 


### PR DESCRIPTION
## Summary
- Adds action menu after emulator selection with "Download Artwork" and "Delete Artwork" options
- Implements "Delete All Images" functionality with confirmation prompt
- Adds individual image selection and deletion capability
- Includes confirmation prompts for all deletion operations to prevent accidents
- Supports both MinUI (.res) and NextUI (.media) folder structures
- Cleans up images from cache directories, ROM folders, and metadata files
- Adds CLAUDE.md file for development guidance

## Test plan
- [ ] Test on tg5040 device with existing artwork
- [ ] Verify "Delete All Images" removes all cached and ROM folder images
- [ ] Test individual image deletion works correctly
- [ ] Confirm both MinUI and NextUI folder structures are handled
- [ ] Validate confirmation prompts prevent accidental deletions
- [ ] Check that cleanup properly removes temporary files

## Changes Made
### New Menu Flow
1. After selecting an emulator, users see action menu with Download/Delete options
2. Delete Artwork option shows "Delete All Images" or "Delete Individual Images"
3. All deletion operations require confirmation

### Functions Added
- `action_menu()` - Shows Download/Delete options for selected emulator
- `delete_menu()` - Shows deletion type options (all vs individual)
- `confirm_action()` - Confirmation dialog for destructive operations
- `delete_all_images()` - Bulk deletion with confirmation
- `select_images_to_delete()` - Lists available images for individual deletion
- `delete_single_image()` - Deletes selected individual image
- Updated `cleanup()` to remove all temporary menu files

### Deletion Scope
- **Cache**: `$SDCARD_PATH/Artwork/$ROM_FOLDER/` (all art types)
- **ROM Folders**: Both `.res/` (MinUI) and `.media/` (NextUI)
- **Metadata**: Cache match files for the emulator

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)